### PR TITLE
Fixed formatP parser so that it reads plain string.

### DIFF
--- a/app/herms.hs
+++ b/app/herms.hs
@@ -17,7 +17,7 @@ import Data.Semigroup ((<>))
 import Data.String    (IsString(..))
 import Data.Ratio
 import Control.Applicative
-import Options.Applicative hiding (str)
+import Options.Applicative
 import Text.Read
 import Control.Exception
 import GHC.IO.Exception
@@ -440,7 +440,7 @@ servingP t =  option auto
 
 -- | @formatP parses import/export formats.
 formatP :: Translator -> Parser String
-formatP t =  option auto
+formatP t =  option str
          (  long  (t Str.format)
          <> short Str.formatShort
          <> help  (t Str.formatDesc)


### PR DESCRIPTION
The old implementation used [option auto] which relies on Read instance of the returned type.
This doesn't play nicely with String as [Read String] parses quoted strings like `"yaml"`, not `yaml`.
We can either use [option str] or [strOption] but I chose the former just because it looks nicer to me.