### PR TITLE
Fix Haddock typo in Portuguese.hs

### DIFF
--- a/src/Lang/Portuguese.hs
+++ b/src/Lang/Portuguese.hs
@@ -75,7 +75,7 @@ portuguese str
   | is removeDesc     = "remover uma receita"
   | is shopping       = "compras"
   | is shoppingDesc   = "gerar uma lista de compras para as receitas"
-  -- | is datadir        = "datadir"
+  --  | is datadir        = "datadir"
   | is datadirDesc    = "mostrar local das receitas e arquivos de configuração"
   | is version        = "versão"
   --  | is versionShort   = "v"


### PR DESCRIPTION
Pre-patch, `cabal haddock` fails with

```
src/Lang/Portuguese.hs:78:3: error:
    parse error on input ‘-- | is datadir        = "datadir"’
   |
78 |   -- | is datadir        = "datadir"
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The problem is that the commented out code starting with `-- |` happens to be (invalid) Haddock notation. This also causes the nix build to fail as noted in #100 (but this PR doesn't close the issue as it also mentions `stack build` failing when nix integration is enabled).

Post-patch, `cabal haddock` succeeds and so does `nix build -f ./nix`.

