### PR TITLE
lts-12.12 -> lts-14.16

### DIFF
--- a/herms.cabal
+++ b/herms.cabal
@@ -78,7 +78,7 @@ library
   other-extensions:    OverloadedStrings, TemplateHaskell, RankNTypes
 
   -- Other library packages from which modules are imported.
-  build-depends:       ansi-terminal >= 0.7 && <0.9
+  build-depends:       ansi-terminal >= 0.7 && <0.10
                      , base >=4.8 && <5
                      , bytestring >= 0.9 && <0.11
                      , directory >= 0.0
@@ -104,9 +104,9 @@ executable herms
   -- Other library packages from which modules are imported.
   build-depends:       herms
                      , aeson -any
-                     , ansi-terminal >= 0.7 && <0.9
+                     , ansi-terminal >= 0.7 && <0.10
                      , base >=4.8 && <5
-                     , brick >= 0.41.2 && <0.47
+                     , brick >= 0.41.2 && <0.48
                      , bytestring -any
                      , directory >= 0.0
                      , filepath >= 1.4 && < 1.5

--- a/nix/pinned-pkgs.nix
+++ b/nix/pinned-pkgs.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
 
-# We've pinned version 18.03 of nixpkgs for reproducible builds.
+# We've pinned nixpkgs for reproducible builds.
 
 # See this link for a tutorial:
 # https://github.com/Gabriel439/haskell-nix/tree/master/project0
@@ -8,6 +8,6 @@
 import (pkgs.fetchFromGitHub {
   owner  = "NixOS";
   repo   = "nixpkgs";
-  rev    = "19.03";
-  sha256 = "0q2m2qhyga9yq29yz90ywgjbn9hdahs7i8wwlq7b55rdbyiwa5dy";
+  rev    = "cc6cf0a96a627e678ffc996a8f9d1416200d6c81";
+  sha256 = "1srjikizp8ip4h42x7kr4qf00lxcp1l8zp6h0r1ddfdyw8gv9001";
 }) { }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
   src = lib.sourceFilesBySuffices ../. [ ".cabal" ".hs" ];
   buildInputs =  [
 
-    (haskell.packages.ghc864.ghcWithHoogle (hpkgs: with hpkgs; [
+    (haskell.packages.ghc865.ghcWithHoogle (hpkgs: with hpkgs; [
       # Add extra library dependencies here
     ] ++ herms.buildInputs ++ herms.propagatedBuildInputs))
     hlint

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-12.12
+resolver: lts-14.16
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- brick-0.41.2
-- vty-5.24
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Fixes #100. I think it also fixes Stack builds in general, since `lts-12.12` provides `yaml-0.8.32` which doesn't satisfy the `yaml >=0.10 && <0.12` constraint `herms.cabal` requires.

It's really only a partial solution though, as peoples' `<nixpkgs>` will always drift from whatever Stack LTS picked (especially since some will be using `nixos` channels and others `nixpkgs-unstable`). Nix-enabled Stack supports being run in a Nix shell, which could use the same pinned nixpkgs as the Nix build does, and so "just work" in the same way by default. If agreed on, I can make a PR for that.