### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Hackage](https://img.shields.io/hackage/v/herms.svg)](https://hackage.haskell.org/package/herms)
 [![stackage LTS
 package](http://stackage.org/package/herms/badge/lts)](http://stackage.org/lts/package/herms)
-![Travis build](https://api.travis-ci.org/JackKiefer/herms.svg?branch=master)
+![Travis build](https://api.travis-ci.org/JackMiranda/herms.svg?branch=master)
 
 HeRM's: a Haskell-based Recipe Manager (yes, food recipes) for the command line.
 


### PR DESCRIPTION
Just noticed that the CI system works, while the badge doesn't.