### PR TITLE
Pin nixpkgs by default for Nix-enabled Stack builds

### DIFF
--- a/nix/stack.nix
+++ b/nix/stack.nix
@@ -1,0 +1,9 @@
+{ nixpkgs ? ./pinned-pkgs.nix }:
+
+let
+  pkgs = import nixpkgs {};
+in
+  pkgs.haskell.lib.buildStackProject {
+    ghc = pkgs.haskell.compiler.ghc865;
+    name = "herms";
+  }

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,3 +30,6 @@ extra-package-dbs: []
 # Extra directories used by stack for building
 # extra-include-dirs: [/path/to/dir]
 # extra-lib-dirs: [/path/to/dir]
+
+nix:
+  shell-file: nix/stack.nix


### PR DESCRIPTION
Nix-enabled builds will use the pinned nixpkgs by default, which can be overridden by, e.g.,

```
stack build --nix-shell-options='--arg nixpkgs <nixpkgs>'
```

Stack builds without Nix integration will be unaffected.