### PR TITLE
recipe: allow some empty fields in YAML/JSON

### DIFF
--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -8,17 +8,14 @@
     - quantity: 1/1
       unit: package
       name: oriental-flavor instant ramen
-      attribute: ""
     - quantity: 1/1
       unit: Cup
       name: frozen stir-fry vegetables
-      attribute: ""
     - quantity: 1/1
       unit: Tbsp
       name: peanut butter
       attribute: chunky or creamy
     - quantity: 0/1
-      unit: ""
       name: Your favorite hot sauce
       attribute: (optional)
   directions:
@@ -45,21 +42,17 @@
     - quantity: 1 / 2
       unit: Cup
       name: black beans
-      attribute: ""
     - quantity: 1 / 2
       unit: tsp
       name: cumin cayenne and paprika
       attribute: ""
     - quantity: 1 / 6
-      unit: ""
       name: avocado
       attribute: cubed or sliced
     - quantity: 1 / 1
       unit: Tbsp
       name: hatch valley salsa
-      attribute: ""
     - quantity: 0 / 1
-      unit: ""
       name: lime juice
       attribute: to garnish
   directions:
@@ -71,4 +64,4 @@
   tags:
     - vegan
     - mexican
-    - easy"
+    - easy

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -6,7 +6,7 @@ import           Data.Char    (toLower)
 import           Data.Maybe
 import           Data.Ord
 import           Data.Ratio
-import           Data.Yaml    ((.=), (.:))
+import           Data.Yaml    ((.=), (.:), (.:?))
 import           GHC.Generics (Generic)
 import           Text.Read    (readMaybe)
 import qualified Data.List       as List
@@ -159,10 +159,13 @@ instance Yaml.ToJSON Ingredient where
 
 instance Yaml.FromJSON Ingredient where
   parseJSON = Yaml.withObject "Ingredient" $ \o -> Ingredient
-    <$> (readFrac  <$> o .: Text.pack "quantity")
-    <*> (parseUnit <$> o .: Text.pack "unit")
+    <$> (readFrac <$> o .: Text.pack "quantity")
+    <*> (parseUnit <$> withDefault o "" "unit")
     <*> (o .: Text.pack "name")
-    <*> (o .: Text.pack "attribute")
+    <*> withDefault o "" "attribute"
+    where withDefault o def name =
+            fromMaybe def <$> o .:? Text.pack name
+
 
 instance Ord Ingredient where
   ingr1 `compare` ingr2 =
@@ -197,11 +200,13 @@ instance Yaml.ToJSON Recipe where
 instance Yaml.FromJSON Recipe where
   parseJSON = Yaml.withObject "Recipe" $ \o -> Recipe
     <$> (o .: Text.pack "name")
-    <*> (o .: Text.pack "description")
-    <*> (o .: Text.pack "serving size")
+    <*> withDefault o "" "description"
+    <*> withDefault o 1 "serving size"
     <*> (o .: Text.pack "ingredients")
     <*> (o .: Text.pack "directions")
-    <*> (o .: Text.pack "tags")
+    <*> withDefault o [] "tags"
+    where withDefault o def name =
+            fromMaybe def <$> o .:? Text.pack name
 
 type RecipeBook = [Recipe]
 


### PR DESCRIPTION
Fixes #108 

A good next step/follow-up issue would be to make these fields truly optional by adding a `Maybe` around them, rather than encoding this with a default value, as in this PR.