### PR TITLE
Yaml parser will now accept num or string as quantity. (+minor cleanup/improvements)

### DIFF
--- a/herms.cabal
+++ b/herms.cabal
@@ -81,6 +81,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       ansi-terminal >= 0.8 && <=0.10.2
                      , base >=4.8 && <5
+                     , brick >= 0.41.2 && <0.49
                      , bytestring >= 0.9 && <0.11
                      , directory >= 0.0
                      , filepath >= 1.4 && < 1.5

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -1,14 +1,36 @@
 module Instances where
 
 import           Generic.Random hiding ((%))
-import           Test.QuickCheck.Arbitrary (Arbitrary(..))
+import           Test.QuickCheck (oneof)
+import           Test.QuickCheck.Arbitrary (Arbitrary(..), genericShrink)
 
 import           Types
 
 -- New Arbitrary instances
 
 instance Arbitrary Unit where
-  arbitrary = genericArbitrary uniform
+  arbitrary = oneof
+    [ pure Tsp
+    , pure Tbsp
+    , pure Cup
+    , pure Oz
+    , pure FlOz
+    , pure Lb
+    , pure Pint
+    , pure Quart
+    , pure Gallon
+    , pure Ml
+    , pure L
+    , pure G
+    -- We need to ensure that units constructed via Other should not be
+    -- a synonym for other units. This is definitely not ideal as changes
+    -- to parseUnit will change the distribution of `Arbitrary Unit`. This
+    -- is a hacky fix for now to avoid flaky tests.
+    , parseUnit <$> arbitrary
+    ]
+  shrink = genericShrink
+
 
 instance Arbitrary Ingredient where
   arbitrary = genericArbitrary uniform
+  shrink = genericShrink


### PR DESCRIPTION
Does this pull request address a current issue or idea in Contributing.md?
#110 

Tell us what you did!
* Quantity parser: now accepts number or string. <s>However, due to library limitations, this may introduce some overhead caused by backtracking. Probably minimal</s> Update: no backtracking since the parsers do not overlap.
* Yaml serialization: will now serialize quantities as numbers whenever possible. Simplified `showFrac`.
* Title border box will now contain multi-width characters properly.
* Fix QuickCheck property test for encode -> decode invariance. Added shrinking to ingredient/unit `Arbitrary` instance. Change unit `Arbitrary` instance so that `Other` units do not overlap with synonyms for the rest of the units.

Before:
![Screen Shot 2020-02-15 at 14 28 23](https://user-images.githubusercontent.com/783631/74596100-7667f280-4fff-11ea-9691-9daea60f7412.png)
After:
![Screen Shot 2020-02-15 at 13 53 02](https://user-images.githubusercontent.com/783631/74596107-85e73b80-4fff-11ea-8e90-d7a2c0449234.png)

Do you have any questions? :)
