### PR TITLE
Improve readFrac so that the input string is read only once (almost)

### DIFF
--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -1,7 +1,7 @@
 module Instances where
 
 import           Generic.Random hiding ((%))
-import           Test.QuickCheck (oneof)
+import           Test.QuickCheck (NonNegative(..), oneof)
 import           Test.QuickCheck.Arbitrary (Arbitrary(..), genericShrink)
 
 import           Types
@@ -28,9 +28,11 @@ instance Arbitrary Unit where
     -- is a hacky fix for now to avoid flaky tests.
     , parseUnit <$> arbitrary
     ]
-  shrink = genericShrink
-
 
 instance Arbitrary Ingredient where
-  arbitrary = genericArbitrary uniform
+  arbitrary = Ingredient
+    <$> (getNonNegative <$> arbitrary)
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
   shrink = genericShrink

--- a/test/Types/Tests.hs
+++ b/test/Types/Tests.hs
@@ -4,7 +4,7 @@ module Types.Tests where
 
 import           Test.Tasty              (TestTree, testGroup)
 import           Test.Tasty.HUnit        (assertFailure, testCase, (@=?), (@?=))
-import           Test.Tasty.QuickCheck   (property, testProperty, (===))
+import           Test.Tasty.QuickCheck   (NonNegative(..), property, testProperty, (===))
 
 import           Data.Yaml               (decodeEither', encode)
 import qualified Data.ByteString.Char8 as BS
@@ -35,8 +35,18 @@ tests = testGroup "Types" $ yaml :
         "1 3/13" @=? showFrac (16 % 13)
     , testCase "showFrac (irreducible)" $
         "2 1/4" @=? showFrac (81 % 36)
+    , testCase "showFrac (integer)" $
+        "9" @=? showFrac (81 % 9)
+    , testCase "readFrac (proper)" $
+        4 % 7 @=? readFrac "4/7"
+    , testCase "readFrac (improper)" $
+        16 % 13 @=? readFrac "1 3/13"
+    , testCase "readFrac (irreducible)" $
+        9 % 4 @=? readFrac "81/36"
+    , testCase "readFrac (integer)" $
+        9 % 1 @=? readFrac "9"
     , testProperty "readFrac . showFrac = id" $
-        \x -> x === readFrac (showFrac x)
+        \y -> let x = getNonNegative y in x === readFrac (showFrac x)
     ]
 
 yaml :: TestTree


### PR DESCRIPTION
Benchmark (99% CI):
* 1M iteration of (readFrac . showFrac) QuickCheck with fixed seed

Old implementation: 32.91s +-0.00
New implementation: 14.21s +-0.00 (67% decrease)

Other changes:
Made it so that the tests only tested positive quantites. Negative
quantities make no sense in this application anyway so we shall not
provide a guarantee on the program's correctness. The old parser parsed
negative improper fractions incorrectly anyway.

Does this pull request address a current issue or idea in Contributing.md?
no

Tell us what you did!
see above

Do you have any questions? :)
no
