### PR TITLE
Use lts-15 (GHC 8.8) and update bounds.

### DIFF
--- a/app/herms.hs
+++ b/app/herms.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Function
 import Data.List
 import Data.Maybe
-import Data.Semigroup ((<>))
+import Data.Monoid
 import Data.String    (IsString(..))
 import Data.Ratio
 import Control.Applicative

--- a/herms.cabal
+++ b/herms.cabal
@@ -79,19 +79,18 @@ library
   other-extensions:    OverloadedStrings, TemplateHaskell, RankNTypes
 
   -- Other library packages from which modules are imported.
-  build-depends:       ansi-terminal >= 0.8 && <=0.10.2
+  build-depends:       ansi-terminal >=0.8 && <0.11
                      , base >=4.10 && <5
-                     , brick >= 0.41.2 && <0.49
-                     , bytestring >= 0.9 && <0.11
-                     , directory >= 0.0
-                     , filepath >= 1.4 && < 1.5
-                     , mtl >= 2.2.1 && < 2.3
+                     , brick >=0.41.2 && <0.53
+                     , bytestring >=0.10 && <0.11
+                     , directory >=1.3 && <1.4
+                     , filepath >=1.4 && <1.5
+                     , mtl >=2.2.1 && <2.3
                      , optparse-applicative >=0.14 && <0.16
-                     , semigroups >= 0.18.3 && <= 0.19.1
+                     , regex-tdfa >=1.2.3 && <1.4
                      , split >=0.2 && <0.3
-                     , text >= 1.1 && <1.3
+                     , text >=1.1 && <1.3
                      , yaml >=0.10 && <0.12
-                     , regex-tdfa >= 1.2.3 && <1.4
 
 executable herms
   hs-source-dirs:      app
@@ -105,20 +104,18 @@ executable herms
 
   -- Other library packages from which modules are imported.
   build-depends:       herms
-                     , aeson -any
-  build-depends:       ansi-terminal >= 0.8 && <=0.10.2
+                     , aeson >=1.4 && <1.5
+                     , ansi-terminal >=0.8 && <0.11
                      , base >=4.10 && <5
-                     , brick >= 0.41.2 && <0.49
-                     , bytestring -any
-                     , directory >= 0.0
-                     , filepath >= 1.4 && < 1.5
+                     , brick >=0.41.2 && <0.53
+                     , bytestring >=0.10 && <0.11
+                     , directory >=1.3 && <1.4
+                     , filepath >=1.4 && <1.5
                      , microlens >=0.4 && <0.5
                      , microlens-th >=0.4 && <0.5
-                     , mtl >= 2.2.1 && < 2.3
+                     , mtl >=2.2.1 && <2.3
                      , optparse-applicative >=0.14 && <0.16
-                     , semigroups >= 0.18.3 && <= 0.19.1
-                     , split >=0.2 && <0.3
-                     , text-zipper >= 0.7.1
+                     , text-zipper >=0.10 && <0.11
                      , vty >=5.26 && <5.27
                      , yaml >=0.10 && <0.12
 
@@ -138,14 +135,13 @@ test-suite herms-test
                          -threaded
     other-extensions:    OverloadedStrings, TemplateHaskell, RankNTypes
     build-depends: herms
-                 , base -any
-                 , bytestring -any
-                 , generic-random -any
-                 , tasty -any
-                 , tasty-hunit -any
-                 , tasty-quickcheck -any
-                 , HUnit -any
-                 , QuickCheck -any
+                 , base >=4.10 && <5
+                 , bytestring >=0.10 && <0.11
+                 , tasty
+                 , tasty-hunit
+                 , tasty-quickcheck
+                 , HUnit
+                 , QuickCheck
                  , yaml >=0.10 && <0.12
 
 source-repository head

--- a/herms.cabal
+++ b/herms.cabal
@@ -80,7 +80,7 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       ansi-terminal >= 0.8 && <=0.10.2
-                     , base >=4.8 && <5
+                     , base >=4.10 && <5
                      , brick >= 0.41.2 && <0.49
                      , bytestring >= 0.9 && <0.11
                      , directory >= 0.0
@@ -107,7 +107,7 @@ executable herms
   build-depends:       herms
                      , aeson -any
   build-depends:       ansi-terminal >= 0.8 && <=0.10.2
-                     , base >=4.8 && <5
+                     , base >=4.10 && <5
                      , brick >= 0.41.2 && <0.49
                      , bytestring -any
                      , directory >= 0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-14.16
+resolver: lts-15.1
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -1,12 +1,9 @@
 module Instances where
 
-import           Generic.Random hiding ((%))
 import           Test.QuickCheck (NonNegative(..), oneof)
 import           Test.QuickCheck.Arbitrary (Arbitrary(..), genericShrink)
 
 import           Types
-
--- New Arbitrary instances
 
 instance Arbitrary Unit where
   arbitrary = oneof


### PR DESCRIPTION
* Bump base to 4.10 (GHC 8.2)
* Bump resolver to lts-15 (GHC 8.8)
* Remove unnecessary dependency on semigroups, generic-random
* Remove unnecessary dependency on split in the executable
* Bump upper bound for ansi-terminal, brick
* Bump lower bound on bytestring to the one shipped with GHC 8.2
* Introduce bounds on aeson to current in lts-15.1
* Introduce bounds on directory to the one shipped with GHC 8.2
* Introduce upper bound on text-zipper, bump lower bound
* Reformat bounds so that they are consistent
----
Does this pull request address a current issue or idea in Contributing.md?
#107 
Tell us what you did!

Do you have any questions? :)
